### PR TITLE
fix syntax errors regarding gulp bundle

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -21,7 +21,6 @@ $(document).ready(function() {
                ['height', ['height']],
                ['code',['codeview']]
           ],
-    ],
     callbacks: {
       onInit: function() {
         console.log('Summernote is launched');


### PR DESCRIPTION
Hi @jrutter,

I tried to follow the instructions from the README.md but stumbled upon the following error:

```
[11:46:12] Using gulpfile ~/dev/extensions/samples/Contentful-WYSIWYG-Editor/gulpfile.js
[11:46:12] Starting 'stylus'...
[11:46:12] Finished 'stylus' after 11 ms
[11:46:12] Starting 'build'...
[11:46:12] Finished 'build' after 60 ms
[11:46:12] Starting 'bundle'...

events.js:182
      throw er; // Unhandled 'error' event
      ^
Error
    at new JS_Parse_Error (/Users/tobiaskrogh/dev/extensions/samples/Contentful-WYSIWYG-Editor/node_modules/inline-source/node_modules/uglify-js/lib/parse.js:196:18)
    at js_error (/Users/tobiaskrogh/dev/extensions/samples/Contentful-WYSIWYG-Editor/node_modules/inline-source/node_modules/uglify-js/lib/parse.js:204:11)
    at croak (/Users/tobiaskrogh/dev/extensions/samples/Contentful-WYSIWYG-Editor/node_modules/inline-source/node_modules/uglify-js/lib/parse.js:680:9)
    at token_error (/Users/tobiaskrogh/dev/extensions/samples/Contentful-WYSIWYG-Editor/node_modules/inline-source/node_modules/uglify-js/lib/parse.js:688:9)
    at unexpected (/Users/tobiaskrogh/dev/extensions/samples/Contentful-WYSIWYG-Editor/node_modules/inline-source/node_modules/uglify-js/lib/parse.js:694:9)
    at as_property_name (/Users/tobiaskrogh/dev/extensions/samples/Contentful-WYSIWYG-Editor/node_modules/inline-source/node_modules/uglify-js/lib/parse.js:1282:13)
    at /Users/tobiaskrogh/dev/extensions/samples/Contentful-WYSIWYG-Editor/node_modules/inline-source/node_modules/uglify-js/lib/parse.js:1236:24
    at /Users/tobiaskrogh/dev/extensions/samples/Contentful-WYSIWYG-Editor/node_modules/inline-source/node_modules/uglify-js/lib/parse.js:727:24
    at expr_atom (/Users/tobiaskrogh/dev/extensions/samples/Contentful-WYSIWYG-Editor/node_modules/inline-source/node_modules/uglify-js/lib/parse.js:1187:35)
    at maybe_unary (/Users/tobiaskrogh/dev/extensions/samples/Contentful-WYSIWYG-Editor/node_modules/inline-source/node_modules/uglify-js/lib/parse.js:1363:19)
```

I looked through the code and found a syntax error in `src/app.js` and fixed it. Do not know whether this repo is still actively maintained. Anyhow :-) 